### PR TITLE
HT-9611/add policy version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,9 @@ resource "aws_s3_bucket_logging" "default" {
 # https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html
 # https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#enable-default-server-side-encryption
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+  /*  WARN: manual change added */
   count  = local.enabled && var.sse_enabled ? 1 : 0
+  /*  End of manual change */
   bucket = join("", aws_s3_bucket.default.*.id)
 
   rule {
@@ -315,10 +317,12 @@ data "aws_iam_policy_document" "bucket_policy" {
 
   /*  WARN: manual change added */
   version = "2012-10-17"
-/*  End of manual change */
+  /*  End of manual change */
 
   dynamic "statement" {
-    for_each = var.allow_encrypted_uploads_only && var.allow_encrypted_uploads_only ? [1] : []
+    /*  WARN: manual change added */
+    for_each = var.sse_enabled && var.allow_encrypted_uploads_only ? [1] : []
+    /*  End of manual change */
 
     content {
       sid       = "DenyIncorrectEncryptionHeader"

--- a/main.tf
+++ b/main.tf
@@ -313,6 +313,10 @@ module "s3_user" {
 data "aws_iam_policy_document" "bucket_policy" {
   count = local.enabled ? 1 : 0
 
+  /*  WARN: manual change added */
+  version = "2012-10-17"
+/*  End of manual change */
+
   dynamic "statement" {
     for_each = var.allow_encrypted_uploads_only && var.allow_encrypted_uploads_only ? [1] : []
 

--- a/variables.tf
+++ b/variables.tf
@@ -329,8 +329,10 @@ variable "bucket_key_enabled" {
   EOT
 }
 
+/*  WARN: manual change added */
 variable "sse_enabled" {
   type        = bool
   default     = true
   description = "Enable default server-side encryption. Default set to `true`"
 }
+/*  End of manual change */


### PR DESCRIPTION
## what
* Add version to the policy
* Mark the added manual changes
* Use `sse_enabled` variable in `DenyIncorrectEncryptionHeader` statement

## why
* Current plans shows that version is going to be removed from the policy document 🤷‍♂️ 
```
   data "aws_iam_policy_document" "bucket_policy"  {
      ~ id      = "1132004489" -> (known after apply)
      ~ json    = jsonencode(
            {
              - Version = "2012-10-17"
            }
        ) -> (known after apply)
      - version = "2012-10-17" -> null
    }
 ```
* There was no reference for the added manual changes added that differ from the remote original branch
* In DenyIncorrectEncryptionHeader statement `sse_enabled` variable wasn't being used

## references
* https://github.com/humn-ai/tf-humn-iac-live/pull/2060

